### PR TITLE
Fix Safari issue with masks and clip-paths.

### DIFF
--- a/src/src/lottie.component.ts
+++ b/src/src/lottie.component.ts
@@ -15,6 +15,8 @@ import { BaseDirective } from './base.directive';
 import { AnimationLoader } from './animation-loader';
 import { LottieEventsFacade } from './events-facade';
 
+const lottie: any = require('lottie-web/build/player/lottie.js');
+
 @Component({
   selector: 'ng-lottie',
   template: `
@@ -41,6 +43,7 @@ export class LottieComponent extends BaseDirective implements OnChanges {
     animationLoader: AnimationLoader,
   ) {
     super(platformId, animationLoader);
+    lottie.setLocationHref(document.location.href);
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

There is an issue with masking in Safari that is described in detail here:
https://github.com/ngx-lottie/ngx-lottie/issues/24

I've noticed that there have been efforts to fix the `href` here:
https://github.com/ngx-lottie/ngx-lottie/pull/25

Also a similar fix is implemented in `ng-lottie` here:
https://github.com/chenqingspring/ng-lottie/pull/35

Unfortunately, the bug still persists and animations don't work properly with masks. What I'm submitting is a quick dirty solution that worked for us in local testing. This might not be optimal due to the fact that this line runs on every component instantiation. Do you have any insights or suggestions on alternatives?

Thank you, your plugin rocks.

Edit: Updated with relevant issue
https://github.com/ngx-lottie/ngx-lottie/issues/65
